### PR TITLE
Proposal for a Code of Ethics and Professional Conduct

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -5,3 +5,4 @@ menu:
   - {name: 'About', url: '/about'}
   - {name: 'Events', url: '/events'}
   - {name: 'Meetup', url: 'https://www.meetup.com/BitDevsLDN/', external: true}
+  - {name: 'Code of Ethics', url: '/code'}

--- a/code.md
+++ b/code.md
@@ -1,0 +1,81 @@
+---
+layout: default
+---
+
+### Code of Ethics and Professional Conduct
+
+London BitDevs aims to be an open forum dedicated in discussing and participating in the research and development
+of Bitcoin and related protocols, in a fair, neutral and productive fashion. In pursuit of those aims, London
+BitDevs organizers aim to preserve and enforce some specific principles.
+
+#### No Discrimination or Harrasment of Meetup Members
+
+During a London BitDevs event, discrimination of any kind towards other event participants are not tolerated.
+London BitDevs aims to foster fair participant of all people, including those of underrepresented groups.
+
+An harrasment is a form of discrimination offendning a specific event participant. Offensive conduct may include,
+but is not limited to, offensive jokes, slurs, epithets, or name calling, physical assaults or threats, intimidation,
+ridicule or mockery, insults or put-downs, offensive objects or picture, and interference with technical discussions.
+
+The offensive criteria must be evaluated in accordance with the manners of London BitDevs as an open forum
+of technical discussions. It should not be used in in bad faith, or prevent discussions of controvesial
+technical subjects, including one related to procedural aspects of Bitcoin FOSS developemnt process.
+
+#### No Ostensible Promotion of Commercial Material
+
+During a London BitDevs event, ostensible and abusive promotion of commercial material or products should
+not be conducted by a participant. Mentions of commercial products by a participant, even as a party of
+interest in the commercial material, is allowed as long as this is relevant to the technical matters
+discussed. It is generally welcomed to be transparent with other participants when one is a party
+of interest in a mentioned commercial material.
+
+Special time during the event can be still be reserved to announcements by the financial and organizational
+event sponsors.
+
+#### Neutrality of Bitcoin Protocol Development
+
+In the occurence of technical topics generating sustained contention during an extended period of time among 
+the Bitcoin community (e.g softforks activation), London BitDevs aims to be a neutral and respectful space for
+every viewpoint present in wider Bitcoin community's communication channels. 
+
+During a London BitDevs event, organizers can recall the neutrality the principle to moderate a
+discussion and distribute fairly time of expression between participants.
+
+#### Chatham House Rule and Event Confidentiality
+
+During a London BitDevs event, participants are free to use the information received, but neither the
+identity, or the affiliation of the speaker, nor that of any other participant can be revealed.
+
+Taking of photos or videos is generally not allowed and respect of the privacy of other members is requested.
+
+#### Enforcement Policy
+
+All London BitDevs meetup members are invited to uphold, promote, and respect the principles of the code,
+during the events and the informal social gatherings around the events.
+
+In case of observed violations, please reach out to the code committe members:
+- Stephan Vuylsteke (TODO)
+- Antoine Riard (london-bitdevs@ariard.me)
+
+One of the member will acknowledge reception of an alleguation of violation under 96 hours
+to the complainant.
+
+Once the code committe members have synced themselves on the subject, they will reached out
+to the subject of complaint and invite to give its version of facts and line of defense under
+a delay of 1 week, unless circumstances request more time.
+
+After receiving the subject answer, or in the lack of it after the delay of 1 week, the code
+committe members will sync themselves on the remediations actions to take, if justified.
+
+If they estimate there is no ground to take a remediation action they will inform the complainant
+of the result.
+
+If they estimate there is ground to take a remediation action among the following:
+- send an email letter to the subject recalling the principles of the code
+- barre the subject from London BitDevs meetup attendance for a specified number of events, or definitively
+
+All the information nature and content communicatted to the code committer members during
+the enforcement process will be treated confidentialy, and only disclosed if grounded
+to appropriate authorities.
+
+Version 0.0.3 - Block 797674 : 000000000000000000029b0ecffadd9a1086e3b335871f76c4193cd8e46a26f5


### PR DESCRIPTION
After discussions with the other London BitDevs organizers, I’ve proposed myself to write a code of ethics and professional conduct to encompass the in-person events and the communication channels surrounding the vents.

The main source of inspirations are the [ACM](https://www.acm.org/code-of-ethics) and the [CoreDev](https://github.com/coredev-tech/coredev-tech.github.io/blob/master/files/CoreDev-Code-of-Conduct.pdf) ones, and some considerations in light of past Bitcoin history (e.g the block size war).

As a disclaimer - While the timing and motivation of proposing such code could be a source of confusion for non-informed observers in reason of recent events concerning my public persona in the wider Bitcoin space, I can assert there is no direct link. The formalization of a code for London BitDevs is coming from autonomous and independent considerations.