### PR TITLE
template: add link to query merged github PRs

### DIFF
--- a/_posts/_template.md
+++ b/_posts/_template.md
@@ -44,6 +44,7 @@ Please speak to the hosts if you're interested in supporting London BitDevs.
 
 ## Pull Requests and repo updates
 ### [Bitcoin Core](https://github.com/bitcoin/bitcoin)
+<!--- Link to query merged PRs since YYYY-MM-DD sorted by descending activity: https://github.com/bitcoin/bitcoin/pulls?page=1&q=is%3Apr+is%3Aclosed+merged%3A%3EYYYY-MM-DD+sort%3Acomments-desc -->
 -
 
 


### PR DESCRIPTION
Quick way to find the recent PRs with a lot of activity. I always find myself searching for this query in my browser history, so figured adding it to the template would be helpful. 