### PR TITLE
n31: fix wrong optech numbering

### DIFF
--- a/_posts/2024-01-31-socratic-seminar-31.md
+++ b/_posts/2024-01-31-socratic-seminar-31.md
@@ -52,11 +52,10 @@ Please speak to the hosts if you're interested in supporting London BitDevs.
 - [Newsletter #280](https://bitcoinops.org/en/newsletters/2023/12/06/), [audio recap](https://bitcoinops.org/en/podcast/2023/12/07/)
 - [Newsletter #281](https://bitcoinops.org/en/newsletters/2023/12/13/), [audio recap](https://bitcoinops.org/en/podcast/2023/12/14/)
 - [Newsletter #282](https://bitcoinops.org/en/newsletters/2023/12/20/), [audio recap](https://bitcoinops.org/en/podcast/2023/12/21/)
-- [Newsletter #283](https://bitcoinops.org/en/newsletters/2023/12/27/), [audio recap](https://bitcoinops.org/en/podcast/2023/12/28/)
-- [Newsletter #284](https://bitcoinops.org/en/newsletters/2024/01/03/), [audio recap](https://bitcoinops.org/en/podcast/2024/01/04/)
-- [Newsletter #285](https://bitcoinops.org/en/newsletters/2024/01/10/), [audio recap](https://bitcoinops.org/en/podcast/2024/01/11/)
-- [Newsletter #286](https://bitcoinops.org/en/newsletters/2024/01/17/), [audio recap](https://bitcoinops.org/en/podcast/2024/01/18/)
-- [Newsletter #287](https://bitcoinops.org/en/newsletters/2024/01/24/), [audio recap](https://bitcoinops.org/en/podcast/2024/01/25/)
+- [Newsletter #283](https://bitcoinops.org/en/newsletters/2024/01/03/), [audio recap](https://bitcoinops.org/en/podcast/2024/01/04/)
+- [Newsletter #284](https://bitcoinops.org/en/newsletters/2024/01/10/), [audio recap](https://bitcoinops.org/en/podcast/2024/01/11/)
+- [Newsletter #285](https://bitcoinops.org/en/newsletters/2024/01/17/), [audio recap](https://bitcoinops.org/en/podcast/2024/01/18/)
+- [Newsletter #286](https://bitcoinops.org/en/newsletters/2024/01/24/), [audio recap](https://bitcoinops.org/en/podcast/2024/01/25/)
 
 ## CVEs and Research
 ### Research


### PR DESCRIPTION
There wasn't a newsletter on 2024-12-27, so the numbering from there on onwards is off by one.